### PR TITLE
ci(workflow): add maintainance-set-assignees-reviewers workflow

### DIFF
--- a/.github/workflows/maintenance-set-assignees-reviewers.yml
+++ b/.github/workflows/maintenance-set-assignees-reviewers.yml
@@ -1,0 +1,116 @@
+name: "[Maintenance] Set assignees and reviewers"
+
+on:
+  workflow_dispatch:
+
+env:
+  AUTH_USER: "bot-anik"
+
+jobs:
+  check-permissions:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Not authorized
+        if: ${{ github.event_name == 'workflow_dispatch' && github.actor != env.AUTH_USER }}
+        run: |
+          echo "Error: Only $AUTH_USER can trigger this workflow."
+          exit 1
+
+  set-assignees-reviewers:
+    runs-on: ubuntu-22.04
+    needs:
+      - check-permissions
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPS_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set assignees and reviewers
+        env:
+          ORG: ${{ github.repository_owner }}
+          REPO_FILTER: --visibility=public --source --no-archived
+          REPO_LIMIT: 100
+          BRANCH_NAME: ci/update-dependabot-assignees-reviewers
+          DEPENDABOT_FILE: .github/dependabot.yml
+          DEPENDABOT_REVIEWERS: "axone-protocol/maintainers"
+          DEPENDABOT_ASSIGNEES: "axone-protocol/maintainers"
+          PR_TITLE: "👩‍🔧 Update Dependabot assignees and reviewers"
+          PR_BODY: |
+            Hey there 👋! I've updated the assignees and reviewers in the Dependabot configuration.
+
+            Please review the changes and merge this pull request if everything looks good. Thanks! ❤️
+          COMMIT_MESSAGE: "ci(dependabot): update assignees and reviewers"
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
+        run: |
+          mkdir -p temp
+          cd temp
+
+          repos=$(gh repo list "$ORG" "$REPO_FILTER" --limit "$REPO_LIMIT" --json nameWithOwner --jq '.[].nameWithOwner' | sort)
+          for repo in $repos; do
+              existing_pr=$(gh pr list --repo "$repo" --head "$BRANCH_NAME" --state open --json number --jq '.[].number')
+              if [[ -n $existing_pr ]]; then
+                  echo "🙅 Existing pull request found for branch $BRANCH_NAME (#$existing_pr). Skipping..."
+                  continue
+              fi
+
+              echo "⬇️ Cloning $repo..."
+              gh repo clone "$repo" -- --depth 1
+
+              repo_name=$(basename "$repo")
+              cd "$repo_name" || { echo "❌ Failed to enter $repo_name"; continue; }
+
+              if [[ -f "$DEPENDABOT_FILE" ]]; then
+                  echo "✅ Dependabot config found. Checking for necessary changes..."
+
+                  YQ_REVIEWERS=$(echo $DEPENDABOT_REVIEWERS | sed 's/ /", "/g')
+                  yq e "(.updates[] | select(.reviewers == null).reviewers) = [\"$YQ_REVIEWERS\"] | (.updates[] | select(has(\"reviewers\")).reviewers) = [\"$YQ_REVIEWERS\"]" -i "$DEPENDABOT_FILE"
+                  YQ_ASSIGNEES=$(echo $DEPENDABOT_ASSIGNEES | sed 's/ /", "/g')
+                  yq e "(.updates[] | select(.assignees == null).assignees) = [\"$YQ_ASSIGNEES\"] | (.updates[] | select(has(\"assignees\")).assignees) = [\"$YQ_ASSIGNEES\"]" -i "$DEPENDABOT_FILE"
+
+                  if [[ -n $(git status -s) ]]; then
+                      echo "✅ Changes detected. Updating Dependabot configuration..."
+                      echo "│"
+                      echo "├── Checking out $BRANCH_NAME..."
+                      git checkout -b "$BRANCH_NAME"
+                      echo "│"
+                      echo "├── Committing changes..."
+                      git add "$DEPENDABOT_FILE"
+                      git commit -S -m "$COMMIT_MESSAGE"
+                      echo "│"
+                      echo "└── Pushing changes..."
+                      git push --set-upstream origin "$BRANCH_NAME"
+
+                      echo "🔀 Creating pull request..."
+                      REVIEWERS=$(echo $DEPENDABOT_REVIEWERS | sed 's/ /,/g')
+                      ASSIGNEES=$(echo $DEPENDABOT_ASSIGNEES | sed 's/ /,/g')
+                      gh pr create \
+                          --title "$PR_TITLE" \
+                          --body "$PR_BODY" \
+                          --reviewer "$REVIEWERS" \
+                          --assignee "$ASSIGNEES" \
+                          --head "$BRANCH_NAME"
+                  else
+                      echo "☑️ No changes required in Dependabot configuration for $repo."
+                  fi
+              else
+                  echo "🙅 No Dependabot config found in $repo."
+              fi
+
+              cd ..
+              rm -rf "$repo_name"
+          done
+
+          cd "$GITHUB_WORKSPACE"
+          rm -rf temp
+
+          echo "🎉 Done!"


### PR DESCRIPTION
Self explanatory.

The workflow must be run by @bot-anik to align the `dependabot` configuration with all the organisation's open source repositories. The workflow is also idempotent and can be replayed as many times as required.